### PR TITLE
qbittorrent in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -93,7 +93,7 @@ jobs:
 
       - name: Docker qbit
         id: docker_qbit
-        uses: ckcr4lyf/actions-kiryuu-qbit-test@v2.2.3
+        uses: ckcr4lyf/actions-kiryuu-qbit-test@v2.2.4
         with:
           torrent_name: hello.txt.torrent
           file_name: hello.txt

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,7 +79,7 @@ jobs:
       - name: Create file, torrent. Add to qbit-svc
         run: |
           whoami
-          chmod -R 777 /qbit-svc
+          sudo chmod -R 777 /qbit-svc
           ls -l /qbit-svc
           mkdir /tmp/imdl
           wget -O imdl.tar.gz https://github.com/casey/intermodal/releases/download/v0.1.12/imdl-v0.1.12-x86_64-unknown-linux-musl.tar.gz

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -93,6 +93,7 @@ jobs:
         uses: ckcr4lyf/actions-kiryuu-qbit-test@v2.2
         with:
           torrent_name: hello.txt.torrent
+          file_name: hello.txt
 
       - name: Kill Kiryuu
         run: kill -9 `lsof -i:6969 -t`

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,6 +84,7 @@ jobs:
           echo "hello" > hello.txt
           sha256sum hello.txt
           /tmp/imdl/imdl torrent create -a http://172.17.0.1:6969/announce hello.txt
+          cp hello.txt /qbit-svc/downloads
 
       - name: Build kiryuu
         run: cargo build
@@ -92,9 +93,7 @@ jobs:
         run: ./target/debug/kiryuu --redis-host 127.0.0.1:6379 &
 
       - name: Copy torrent to watch dir
-        run: |
-          cp hello.txt /qbit-svc/downloads
-          cp hello.txt.torrent /qbit-svc/watch
+        run: cp hello.txt.torrent /qbit-svc/watch
 
       - name: Healthcheck
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -83,7 +83,7 @@ jobs:
           tar xvzf imdl.tar.gz -C /tmp/imdl
           echo "hello" > hello.txt
           sha256sum hello.txt
-          imdl torrent create http://172.17.0.1:6969/announce hello.txt
+          /tmp/imdl/imdl torrent create http://172.17.0.1:6969/announce hello.txt
 
       - name: Build kiryuu
         run: cargo build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,44 +4,17 @@ name: Build & Test
 
 jobs:
   check:
-    name: Check
+    name: Build & Test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3
 
-      - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
+      - name: Build
+        run: cargo build --verbose
 
-      - name: Run cargo check
-        uses: actions-rs/cargo@v1
-        continue-on-error: false
-        with:
-          command: check
-
-  test:
-    name: Test Suite
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@v2
-
-      - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-
-      - name: Run cargo test
-        uses: actions-rs/cargo@v1
-        continue-on-error: false
-        with:
-          command: test
+      - name: Test
+        run: cargo test --verbose
 
   redis-test:
     name: Test with redis-test
@@ -111,7 +84,7 @@ jobs:
           fi
 
       - name: Docker qbit
-        uses: ckcr4lyf/actions-kiryuu-qbit-test@v2
+        uses: ckcr4lyf/actions-kiryuu-qbit-test@v2.1
         with:
           torrent_name: hello.txt.torrent
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -111,7 +111,7 @@ jobs:
           fi
 
       - name: Docker qbit
-        uses: ckcr4lyf/actions-kiryuu-qbit-test@latest
+        uses: ckcr4lyf/actions-kiryuu-qbit-test@v2
         with:
           torrent_name: hello.txt.torrent
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,24 +48,28 @@ jobs:
       - name: Check out repository code
         uses: actions/checkout@v3
 
-      - name: Create file, torrent. Add to qbit-svc
+      - name: chmod the qbit seeder volumes
+        run: sudo chmod -R 777 /qbit-svc
+
+      - name: Start tcpdump on shared docker interface
         run: |
-          ifconfig
-          sudo apt-get -y install tcpdump
-          tcpdump --version
           IF_NAME="$(ifconfig | grep -B1 "172.18.0.1" | head -n1 | awk '{print $1}' | cut -d ':' -f1)"
-          echo $IF_NAME
           sudo tcpdump -nnSX port 6969 -i $IF_NAME &>tcpdump_host.log &
-          whoami
-          sudo chmod -R 777 /qbit-svc
-          ls -l /qbit-svc
+
+      - name: Download imdl (thanks @casey)
+        run: |
           mkdir /tmp/imdl
           wget -O imdl.tar.gz https://github.com/casey/intermodal/releases/download/v0.1.12/imdl-v0.1.12-x86_64-unknown-linux-musl.tar.gz
           tar xvzf imdl.tar.gz -C /tmp/imdl
+
+      - name: Make dummy hello torrent (announce to kiryuu IP)
+        run: |
           echo "hello" > hello.txt
           sha256sum hello.txt
           /tmp/imdl/imdl torrent create -a http://172.17.0.1:6969/announce hello.txt
-          cp hello.txt /qbit-svc/downloads/
+
+      - name: Copy text file to seeder qbit instance
+        run: cp hello.txt /qbit-svc/downloads/
 
       - name: Build kiryuu
         run: cargo build
@@ -76,7 +80,7 @@ jobs:
       - name: Copy torrent to watch dir
         run: cp hello.txt.torrent /qbit-svc/watch/
 
-      - name: Healthcheck
+      - name: Healthcheck on kiryuu
         run: |
           if [[ "$(curl -s -o /dev/null -w ''%{http_code}'' http://127.0.0.1:6969/healthz)" != "200" ]]
             then exit 1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -112,18 +112,11 @@ jobs:
 
       - name: Docker qbit
         uses: ckcr4lyf/actions-kiryuu-qbit-test@latest
-      
-      - name: Announce
-        run: curl -v http://127.0.0.1:6969/announce
+        with:
+          torrent_name: hello.txt.torrent
 
       - name: Kill Kiryuu
         run: kill -9 `lsof -i:6969 -t`
-
-      - name: Upload qBittorrent service log
-        uses: actions/upload-artifact@v3
-        with:
-          name: qbit_data
-          path: /qbit-svc/downloads
 
       - name: tcpdump logs
         uses: actions/upload-artifact@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,17 +69,32 @@ jobs:
         volumes:
           - /qbit-svc/downloads:/downloads
           - /qbit-svc/watch:/watch
+          - /qbit-svc/logs:/root/.local/share/qBittorrent/logs
 
     steps:
       # Downloads a copy of the code in your repository before running CI tests
       - name: Check out repository code
         uses: actions/checkout@v3
 
+      - name: Create file, torrent. Add to qbit-svc
+        run: |
+          mkdir /tmp/imdl
+          wget -O imdl.tar.gz https://github.com/casey/intermodal/releases/download/v0.1.12/imdl-v0.1.12-x86_64-unknown-linux-musl.tar.gz
+          tar xvzf imdl.tar.gz -C /tmp/imdl
+          echo "hello" > hello.txt
+          sha256sum hello.txt
+          imdl torrent create http://172.17.0.1:6969/announce hello.txt
+
       - name: Build kiryuu
         run: cargo build
 
       - name: Run kiryuu (in background)
         run: ./target/debug/kiryuu --redis-host 127.0.0.1:6379 &
+
+      - name: Copy torrent to watch dir
+        run: |
+          cp hello.txt /qbit-svc/downloads
+          cp hello.txt.torrent /qbit-svc/watch
 
       - name: Healthcheck
         run: |
@@ -96,6 +111,12 @@ jobs:
 
       - name: Kill Kiryuu
         run: kill -9 `lsof -i:6969 -t`
+
+      - name: Upload qBittorrent service log
+        uses: actions/upload-artifact@v3
+        with:
+          name: qbit_svc_log.txt
+          path: /qbit-svc/logs/qbittorrent.log   
 
       - name: tcpdump log
         uses: actions/upload-artifact@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,8 +69,8 @@ jobs:
           echo "OG_SHA=$(sha256sum hello.txt)" >> $GITHUB_OUTPUT
           /tmp/imdl/imdl torrent create -a http://172.17.0.1:6969/announce hello.txt
 
-      - name: Copy text file to seeder qbit instance
-        run: cp hello.txt /qbit-svc/downloads/
+      - name: Move text file to seeder qbit instance
+        run: mv hello.txt /qbit-svc/downloads/
 
       - name: Build kiryuu
         run: cargo build
@@ -88,6 +88,9 @@ jobs:
             else exit 0
           fi
 
+      - name: Do some listing
+        run: ls -la          
+
       - name: Docker qbit
         id: docker_qbit
         uses: ckcr4lyf/actions-kiryuu-qbit-test@v2.2.1
@@ -99,7 +102,7 @@ jobs:
         run: kill -9 `lsof -i:6969 -t`
 
       - name: Do some listing
-        run: ls -l        
+        run: ls -la
 
       - name: Compare hashes
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,9 +63,10 @@ jobs:
           tar xvzf imdl.tar.gz -C /tmp/imdl
 
       - name: Make dummy hello torrent (announce to kiryuu IP)
+        id: make_torrent
         run: |
           echo "hello" > hello.txt
-          sha256sum hello.txt
+          echo "OG_SHA=$(sha256sum hello.txt)" >> $GITHUB_OUTPUT
           /tmp/imdl/imdl torrent create -a http://172.17.0.1:6969/announce hello.txt
 
       - name: Copy text file to seeder qbit instance
@@ -88,12 +89,26 @@ jobs:
           fi
 
       - name: Docker qbit
-        uses: ckcr4lyf/actions-kiryuu-qbit-test@v2.1
+        id: docker_qbit
+        uses: ckcr4lyf/actions-kiryuu-qbit-test@v2.2
         with:
           torrent_name: hello.txt.torrent
 
       - name: Kill Kiryuu
         run: kill -9 `lsof -i:6969 -t`
+
+      - name: Compare hashes
+        env:
+          OG_SHA: ${{ steps.make_torrent.outputs.og_sha }}
+          NEW_SHA: ${{ steps.docker_qbit.outputs.sha }}
+        run: |
+          if [[ $OG_SHA != $NEW_SHA ]]
+            then
+              echo "Fail, OG_SHA=$OG_SHA, but NEW_SHA=$NEW_SHA"
+              exit 1
+            else
+              echo "Success, OG_SHA=$OG_SHA and NEW_SHA=$NEW_SHA"
+          fi          
 
       - name: tcpdump logs
         uses: actions/upload-artifact@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,7 +79,7 @@ jobs:
           fi
 
       - name: Docker qbit
-        uses: docker://ghcr.io/ckcr4lyf/qnox:latest
+        uses: ckcr4lyf/actions-kiryuu-qbit-test
       
       - name: Announce
         run: curl -v http://127.0.0.1:6969/announce

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,7 +81,9 @@ jobs:
           ifconfig
           sudo apt-get -y install tcpdump
           tcpdump --version
-          sudo tcpdump -nnSX port 6969 -i docker0 &>tcpdump_host.log &
+          IF_NAME="$(ifconfig | grep -B1 "172.18.0.1" | head -n1 | awk '{print $1}' | cut -d ':' -f1)"
+          echo $IF_NAME
+          sudo tcpdump -nnSX port 6969 -i $IF_NAME &>tcpdump_host.log &
           whoami
           sudo chmod -R 777 /qbit-svc
           ls -l /qbit-svc

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,8 +69,6 @@ jobs:
         volumes:
           - /qbit-svc/downloads:/downloads
           - /qbit-svc/watch:/watch
-          - /qbit-svc/config:/root/.config/qBittorrent
-          - /qbit-svc/local-share:/root/.local/share/qBittorrent
 
     steps:
       # Downloads a copy of the code in your repository before running CI tests
@@ -125,10 +123,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: qbit_data
-          path: |
-            /qbit-svc/config
-            /qbit-svc/local-share
-            !/qbit-svc/config/ipc-socket
+          path: /qbit-svc/downloads
 
       - name: tcpdump logs
         uses: actions/upload-artifact@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,7 +66,7 @@ jobs:
         id: make_torrent
         run: |
           echo "hello" > hello.txt
-          echo "OG_SHA=$(sha256sum hello.txt)" >> $GITHUB_OUTPUT
+          echo "OG_SHA=$(sha256sum hello.txt | awk '{print $1}')" >> $GITHUB_OUTPUT
           /tmp/imdl/imdl torrent create -a http://172.17.0.1:6969/announce hello.txt
 
       - name: Move text file to seeder qbit instance
@@ -88,21 +88,15 @@ jobs:
             else exit 0
           fi
 
-      - name: Do some listing
-        run: ls -la          
-
-      - name: Docker qbit
+      - name: Run qbit leecher
         id: docker_qbit
-        uses: ckcr4lyf/actions-kiryuu-qbit-test@v2.2.4
+        uses: ckcr4lyf/actions-kiryuu-qbit-test@v2.2.5
         with:
           torrent_name: hello.txt.torrent
           file_name: hello.txt
 
       - name: Kill Kiryuu
         run: kill -9 `lsof -i:6969 -t`
-
-      - name: Do some listing
-        run: ls -la
 
       - name: Compare hashes
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,7 +79,7 @@ jobs:
           fi
 
       - name: Docker qbit
-        uses: ckcr4lyf/actions-kiryuu-qbit-test
+        uses: ckcr4lyf/actions-kiryuu-qbit-test@latest
       
       - name: Announce
         run: curl -v http://127.0.0.1:6969/announce

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,11 +78,17 @@ jobs:
             else exit 0
           fi
 
-      - name: Docker healthcheck
-        uses: docker://ghcr.io/ckcr4lyf/xd:latest          
+      - name: Docker qbit
+        uses: docker://ghcr.io/ckcr4lyf/qnox:latest
       
       - name: Announce
         run: curl -v http://127.0.0.1:6969/announce
 
       - name: Kill Kiryuu
         run: kill -9 `lsof -i:6969 -t`
+
+      - name: tcpdump log
+        uses: actions/upload-artifact@v3
+        with:
+          name: tcpdump.log
+          path: /logs/tcpdump.log

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -93,7 +93,7 @@ jobs:
 
       - name: Docker qbit
         id: docker_qbit
-        uses: ckcr4lyf/actions-kiryuu-qbit-test@v2.2.1
+        uses: ckcr4lyf/actions-kiryuu-qbit-test@v2.2.2
         with:
           torrent_name: hello.txt.torrent
           file_name: hello.txt

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -83,7 +83,7 @@ jobs:
           tar xvzf imdl.tar.gz -C /tmp/imdl
           echo "hello" > hello.txt
           sha256sum hello.txt
-          /tmp/imdl/imdl torrent create http://172.17.0.1:6969/announce hello.txt
+          /tmp/imdl/imdl torrent create -a http://172.17.0.1:6969/announce hello.txt
 
       - name: Build kiryuu
         run: cargo build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -93,7 +93,7 @@ jobs:
 
       - name: Docker qbit
         id: docker_qbit
-        uses: ckcr4lyf/actions-kiryuu-qbit-test@v2.2.2
+        uses: ckcr4lyf/actions-kiryuu-qbit-test@v2.2.3
         with:
           torrent_name: hello.txt.torrent
           file_name: hello.txt

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,6 +60,16 @@ jobs:
           --health-timeout 5s
           --health-retries 5
 
+      qbit-svc:
+        image: ghcr.io/ckcr4lyf/qbit-svc
+
+        ports:
+          - 8888:8080
+
+        volumes:
+          - /qbit-svc/downloads:/downloads
+          - /qbit-svc/watch:/watch
+
     steps:
       # Downloads a copy of the code in your repository before running CI tests
       - name: Check out repository code

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,6 +78,9 @@ jobs:
 
       - name: Create file, torrent. Add to qbit-svc
         run: |
+          ifconfig
+          sudo apt-get -y install tcpdump
+          tcpdump --version
           whoami
           sudo chmod -R 777 /qbit-svc
           ls -l /qbit-svc

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -128,6 +128,7 @@ jobs:
           path: |
             /qbit-svc/config
             /qbit-svc/local-share
+            !/qbit-svc/config/ipc-socket
 
       - name: tcpdump logs
         uses: actions/upload-artifact@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -91,4 +91,4 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: tcpdump.log
-          path: /logs/tcpdump.log
+          path: ./tcpdump.log

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -90,13 +90,16 @@ jobs:
 
       - name: Docker qbit
         id: docker_qbit
-        uses: ckcr4lyf/actions-kiryuu-qbit-test@v2.2
+        uses: ckcr4lyf/actions-kiryuu-qbit-test@v2.2.1
         with:
           torrent_name: hello.txt.torrent
           file_name: hello.txt
 
       - name: Kill Kiryuu
         run: kill -9 `lsof -i:6969 -t`
+
+      - name: Do some listing
+        run: ls -l        
 
       - name: Compare hashes
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,6 +81,7 @@ jobs:
           ifconfig
           sudo apt-get -y install tcpdump
           tcpdump --version
+          sudo tcpdump -nnSX port 6969 -i docker0 &>tcpdump_host.log &
           whoami
           sudo chmod -R 777 /qbit-svc
           ls -l /qbit-svc
@@ -121,10 +122,12 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: qbit_svc_log.txt
-          path: /qbit-svc/logs/qbittorrent.log   
+          path: /qbit-svc/logs/qbittorrent.log
 
-      - name: tcpdump log
+      - name: tcpdump logs
         uses: actions/upload-artifact@v3
         with:
-          name: tcpdump.log
-          path: ./tcpdump.log
+          name: tcpdump_logs
+          path: |
+            ./tcpdump.log
+            ./tcpdump_host.log

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,6 +78,9 @@ jobs:
 
       - name: Create file, torrent. Add to qbit-svc
         run: |
+          whoami
+          chmod -R 777 /qbit-svc
+          ls -l /qbit-svc
           mkdir /tmp/imdl
           wget -O imdl.tar.gz https://github.com/casey/intermodal/releases/download/v0.1.12/imdl-v0.1.12-x86_64-unknown-linux-musl.tar.gz
           tar xvzf imdl.tar.gz -C /tmp/imdl

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,7 +69,8 @@ jobs:
         volumes:
           - /qbit-svc/downloads:/downloads
           - /qbit-svc/watch:/watch
-          - /qbit-svc/logs:/root/.local/share/qBittorrent/logs
+          - /qbit-svc/config:/root/.config/qBittorrent
+          - /qbit-svc/local-share:/root/.local/share/qBittorrent
 
     steps:
       # Downloads a copy of the code in your repository before running CI tests
@@ -93,7 +94,7 @@ jobs:
           echo "hello" > hello.txt
           sha256sum hello.txt
           /tmp/imdl/imdl torrent create -a http://172.17.0.1:6969/announce hello.txt
-          cp hello.txt /qbit-svc/downloads
+          cp hello.txt /qbit-svc/downloads/
 
       - name: Build kiryuu
         run: cargo build
@@ -102,7 +103,7 @@ jobs:
         run: ./target/debug/kiryuu --redis-host 127.0.0.1:6379 &
 
       - name: Copy torrent to watch dir
-        run: cp hello.txt.torrent /qbit-svc/watch
+        run: cp hello.txt.torrent /qbit-svc/watch/
 
       - name: Healthcheck
         run: |
@@ -123,8 +124,10 @@ jobs:
       - name: Upload qBittorrent service log
         uses: actions/upload-artifact@v3
         with:
-          name: qbit_svc_log.txt
-          path: /qbit-svc/logs/qbittorrent.log
+          name: qbit_data
+          path: |
+            /qbit-svc/config
+            /qbit-svc/local-share
 
       - name: tcpdump logs
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
This PR adds qbittorrent based testing in CI. Specifically, it does the following:

1. Deploy a redice service container (Kiryuu dependency)
2. Deploy a custom qbit-svc container for seeding (see: https://github.com/ckcr4lyf/actions-kiryuu-qbit-test/tree/master/service)
3. Create a dummy file and a torrent for it, set the announce to kiryuu's IP
4. Use a custom qbit action which will try and download the dummy torrent (see: https://github.com/ckcr4lyf/actions-kiryuu-qbit-test)
5. Compare SHAs at the end

This helps confirm that kiryuu can:
1. Process announce from initial seeder
2. Handle announce from leecher, and return the seeders connection info (We verify this by checking the download completed).

Potential Future Improvements:

* Have some custom announces etc. via cURL (mock source IP?)
