### PR TITLE
Record announces with no change

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -7,3 +7,25 @@ name: Master - Build, Unit Test, Integration test
 jobs:
   integration-tests:
     uses: ./.github/workflows/integration_test.yml
+
+  build-static:
+    name: Build Static
+    needs: integration-tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v3
+
+      - name: Add musl target
+        run: rustup target add x86_64-unknown-linux-musl
+
+      - name: Build static binary
+        run: cargo build --target=x86_64-unknown-linux-musl --release
+
+      - name: Check linkage
+        run: ldd ./target/x86_64-unknown-linux-musl/release/kiryuu
+      
+      - uses: actions/upload-artifact@v3
+        with:
+          name: kiryuu-static-${{ github.sha }}
+          path: ./target/x86_64-unknown-linux-musl/release/kiryuu

--- a/src/constants/mod.rs
+++ b/src/constants/mod.rs
@@ -1,3 +1,4 @@
 pub const ANNOUNCE_COUNT_KEY: &str = "kiryuu_http_announce_count";
+pub const NOCHANGE_ANNOUNCE_COUNT_KEY: &str = "kiryuu_http_nochange_announce_count"; // If no change to seeder_count / leecher_count
 pub const REQ_DURATION_KEY: &str = "kiryuu_http_req_seconds_sum";
 pub const TORRENTS_KEY: &str = "TORRENTS";

--- a/src/main.rs
+++ b/src/main.rs
@@ -167,6 +167,12 @@ async fn announce(req: HttpRequest, data: web::Data<AppState>) -> HttpResponse {
     post_announce_pipeline.cmd("INCR").arg(constants::ANNOUNCE_COUNT_KEY).ignore();
     post_announce_pipeline.cmd("INCRBY").arg(constants::REQ_DURATION_KEY).arg(req_duration).ignore();
 
+    // If neither seeder count changed, neither leech count
+    // In future, we will use this to determine if we need to update the cache or not
+    if seed_count_mod == 0 && leech_count_mod == 0 {
+        post_announce_pipeline.cmd("INCR").arg(constants::NOCHANGE_ANNOUNCE_COUNT_KEY).ignore();
+    }
+
     actix_web::rt::spawn(async move {
         // 0.1% chance to trigger a clean, 
         let chance = rand::thread_rng().gen_range(0..1000);


### PR DESCRIPTION
This will help determine how much we can cache the **entire** announce response (Which includes seeder count, leech count), since that would not have changed

Specifically, this can help determine whether we can:
1. Use inaccurate caching - just set an expiry on the cache (e.g. 60 secs), and accept that within 60 secs the real value might have changed
2. Accurate caching - always update the cache when seedcount / leechcount changes.

If the NOCHANGE ratio is high, then implementing (2) will have a very low cost, since writes won't be as necessary.