### PR TITLE
Use underlying std::net::Ipv4Addr

### DIFF
--- a/benches/ip_str_to_bytes.rs
+++ b/benches/ip_str_to_bytes.rs
@@ -4,7 +4,6 @@ use criterion::{black_box, criterion_group, criterion_main, Criterion};
 
 fn criterion_benchmark(c: &mut Criterion) {
     let mut group = c.benchmark_group("IP str to bytes");
-    group.bench_function("&str", |b| b.iter(|| byte_functions::ip_str_port_u16_to_bytes_old(black_box("123.45.99.31"), black_box(27017)) ));
     group.bench_function("std::net::Ipv4Addr", |b| b.iter(|| byte_functions::ip_str_port_u16_to_bytes(black_box(&std::net::Ipv4Addr::new(123, 45, 99, 31)), black_box(27017)) ));
     group.finish();
 }

--- a/benches/ip_str_to_bytes.rs
+++ b/benches/ip_str_to_bytes.rs
@@ -4,7 +4,8 @@ use criterion::{black_box, criterion_group, criterion_main, Criterion};
 
 fn criterion_benchmark(c: &mut Criterion) {
     let mut group = c.benchmark_group("IP str to bytes");
-    group.bench_function("u8", |b| b.iter(|| byte_functions::ip_str_port_u16_to_bytes(black_box("123.45.99.31"), black_box(27017)) ));
+    group.bench_function("&str", |b| b.iter(|| byte_functions::ip_str_port_u16_to_bytes_old(black_box("123.45.99.31"), black_box(27017)) ));
+    group.bench_function("std::net::Ipv4Addr", |b| b.iter(|| byte_functions::ip_str_port_u16_to_bytes(black_box(&std::net::Ipv4Addr::new(123, 45, 99, 31)), black_box(27017)) ));
     group.finish();
 }
 

--- a/src/byte_functions/mod.rs
+++ b/src/byte_functions/mod.rs
@@ -66,27 +66,6 @@ fn nibble_to_ascii(nibble: u8) -> u8 {
     }
 }
 
-pub fn ip_str_port_u16_to_bytes_old(ip_str: &str, port: u16) -> [u8; 6] {
-    let mut result: [u8; 6] = [0; 6];
-    let mut parts = ip_str.split('.');
-
-    for i in 0..4 {
-        result[i] = match parts.next() {
-            Some(v) => match v.parse::<u8>() {
-                Ok(v) => v,
-                Err(_) => 0,
-            }
-            None => 0,
-        }
-    }    
-    
-    let portu8 = port.to_be_bytes();
-    result[4] = portu8[0];
-    result[5] = portu8[1];
-
-    return result;
-}
-
 // Convert the ipv4 addr, port combo to a [u8; 6]
 pub fn ip_str_port_u16_to_bytes(ip_addr: &std::net::Ipv4Addr, port: u16) -> [u8; 6] {
     let mut result: [u8; 6] = [0; 6];

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,7 @@ mod constants;
 mod req_log;
 
 use actix_web::{get, App, HttpServer, web, HttpRequest, HttpResponse, http::header, http::StatusCode};
-use std::{time::{SystemTime, UNIX_EPOCH}, net::{SocketAddrV4, SocketAddr}};
+use std::{time::{SystemTime, UNIX_EPOCH}};
 use clap::Parser;
 
 /// Simple
@@ -192,6 +192,8 @@ async fn announce(req: HttpRequest, data: web::Data<AppState>) -> HttpResponse {
 
     actix_web::rt::spawn(async move {
         // log the summary
+        // TODO: For now removed this since we no longer have string IP
+        // in future can enable via compilation feature
         // post_announce_pipeline.cmd("PUBLISH").arg("reqlog").arg(req_log::generate_csv(&user_ip_owned, &parsed.info_hash)).ignore();
 
 

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -38,7 +38,7 @@ impl From<serde_qs::Error> for QueryError {
     }
 }
 
-pub fn parse_announce(ip_str: &str, query: &[u8]) -> Result<PeerInfo, QueryError> {
+pub fn parse_announce(ip_addr: &std::net::Ipv4Addr, query: &[u8]) -> Result<PeerInfo, QueryError> {
 
     // Solution: manually parse & encoded infohash from `&info_hash=.........&xyz=.....
     let parsed: AReq = qs::from_bytes(query)?;
@@ -56,7 +56,7 @@ pub fn parse_announce(ip_str: &str, query: &[u8]) -> Result<PeerInfo, QueryError
     };
 
     return Ok(PeerInfo{
-        ip_port: byte_functions::ip_str_port_u16_to_bytes(ip_str, parsed.port),
+        ip_port: byte_functions::ip_str_port_u16_to_bytes(ip_addr, parsed.port),
         info_hash: hex_str_info_hash.to_string(),
         is_seeding,
         event: parsed.event,


### PR DESCRIPTION
Removes "parsing" entirely, so getting the `[u8; 6]` of IP & port is much faster

benchmark:

```
IP str to bytes/&str    time:   [32.792 ns 32.899 ns 33.033 ns]
IP str to bytes/std::net::Ipv4Addr
                        time:   [2.0008 ns 2.0097 ns 2.0194 ns]
```