### PR TITLE
Add the ZADDS

### DIFF
--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -145,3 +145,4 @@ jobs:
         env:
           KIRYUU_HOST: http://172.17.0.1:6969
           REDIS_HOST: redis://172.17.0.1:6379
+          ANNOUNCE_IP_PORT: AC120003115C #172.18.0.3:4444 <- This is the IP kiryuu will see the announce come from, so what we need to hardcode in redis via Gauge


### PR DESCRIPTION
This will make sure that seeders / leechers are updated in redis w/ timestamp, so cleanup job wont remove.

Pros:
* Cleanup wont remove them, so more cache hits (adding re-adding invalidates cache)

Cons:
* ZADD on every announce

Will pros > cons? Find out next time on...