### PR TITLE
Half the redis key size

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1001,6 +1001,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
 name = "http"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1312,6 +1318,7 @@ dependencies = [
  "actix-web",
  "clap 4.0.30",
  "criterion",
+ "hex",
  "opentelemetry",
  "opentelemetry-jaeger",
  "opentelemetry-otlp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ path = "examples/redis_zset.rs"
 
 [dev-dependencies]
 criterion = "0.4"
+hex = "0.4.3"
 
 [[bench]]
 name = "url_enc_to_hex"

--- a/examples/redis_fix_keys.rs
+++ b/examples/redis_fix_keys.rs
@@ -60,6 +60,12 @@ fn migrate_hash(new_server: &mut redis::Connection, key: &Vec<u8>, data: &HashMa
     // println!("For {}, we set {:?}", key, data);
 }
 
+fn migrate_zset(new_server: &mut redis::Connection, new_key: &Vec<u8>, data: Vec<(Vec<u8>, f64)>){
+    for (peer_address, score) in data {
+        let () = new_server.zadd(new_key, peer_address, score).expect("failed to ZADD");
+    }
+}
+
 
 fn migrate_torrrents_zset(old_server: &mut redis::Client, new_server: &mut redis::Client){
     let all_torrents: Vec<(Vec<u8>, f64)> = old_server.zrangebyscore_withscores("TORRENTS", "-inf", "+inf").expect("failed to ZRANGEBYSCORE");

--- a/examples/redis_fix_keys.rs
+++ b/examples/redis_fix_keys.rs
@@ -32,15 +32,17 @@ fn main(){
         } else if element.len() > 42 {
             // len more than 40, should be *_seeders or *_leechers
             unsafe { println!("Got key: {}", String::from_utf8_unchecked(element.clone())); }
+            
+            // construct the new key
             let mut new_key: Vec<u8> = vec![0u8; 20];
             hex::decode_to_slice(&element[0..40], &mut new_key).expect("failed to decode");
             new_key.push(b':');
             new_key.push(element[41]);
-            // new_key[21] = element[41]; // either 's' or 'l'
-
             println!("new key is {:02x?}", new_key);
 
             // migrate the ZSET
+            let peers_with_scores: Vec<(Vec<u8>, f64)> = r_old_2.zrangebyscore_withscores(&element, "-inf", "+inf").expect("fail to get zset");
+            println!("We got {:?}", peers_with_scores);
         }
     }
 }

--- a/examples/redis_fix_keys.rs
+++ b/examples/redis_fix_keys.rs
@@ -1,11 +1,77 @@
+use std::collections::HashMap;
+
 use redis::Commands;
 
 fn main(){
     let mut r_old = redis::Client::open("redis://127.0.0.1:6379").unwrap();
+    let mut dupe = r_old.clone();
     let mut r_new = redis::Client::open("redis://127.0.0.1:6363").unwrap();
 
     // All torrents are in the ZSET TORRENTS
-    let all_torrents: Vec<(Vec<u8>, f64)> = r_old.zrangebyscore_withscores("TORRENTS", "-inf", "+inf").expect("failed to ZRANGEBYSCORE");
+    // Migrate those...
+    // migrate_torrrents_zset(&mut r_old, &mut r_new);
+
+    // for the others we need to scan
+    let mut x = r_old.scan::<String>().expect("fail to scan");
+
+    let mut outer = 0;
+    let mut count = 0;
+    loop {
+        // let a = 
+        let mut inner = 0;
+        if let Some(element) = x.next() {
+            // println!("Got key: {}", element);
+
+            // based on design of kiryuu:
+            // If the key is 40 characters, then its a hash
+            // If it is more, then it is likely a ZSET (`_seeders` or `_leechers`)
+            // println!("New scan loop");
+            if element.len() == 40 {
+                
+                let content: HashMap<String, String> = dupe.hgetall(&element).expect("fail to get it");
+
+                if inner == 0 {
+                    println!("Got key: {}", element);
+                    println!("We got {:?}", content);
+                }
+
+                inner += 1;
+                
+                migrate_hash(&mut r_new, &element, &content);
+                count += 1;
+                // break;
+            }
+        } else {
+            println!("Scan is complete")
+        }
+
+        outer += 1;
+        println!("{} scans done!", outer);
+
+        if outer == 100000 {
+            break;
+        }
+    }
+
+    println!("Did total: {}", count);
+}
+
+fn migrate_hash(new_server: &mut redis::Client, key: &str, data: &HashMap<String, String>){
+    let new_key = hex::decode(key).expect("failed to decode");
+    // new_server.hset_multiple(new_key, data.);
+
+    for (realkey, value) in data {
+        let _: () = new_server.hset(&new_key, realkey, value).expect("fail to hset");
+        // println!("We pogging with {} and {} into {:2X?}", realkey, value, new_key);
+    }
+    // new_server.hset(key, field, value)
+
+    // println!("For {}, we set {:?}", key, data);
+}
+
+
+fn migrate_torrrents_zset(old_server: &mut redis::Client, new_server: &mut redis::Client){
+    let all_torrents: Vec<(Vec<u8>, f64)> = old_server.zrangebyscore_withscores("TORRENTS", "-inf", "+inf").expect("failed to ZRANGEBYSCORE");
 
     println!("Got {} torrents", all_torrents.len());
 
@@ -15,15 +81,6 @@ fn main(){
         }
 
         let raw_infohash = hex::decode(&all_torrents[i].0).expect("Failed to decode");
-        r_new.zadd::<&str, f64, &Vec<u8>, ()>("TORRENTS", &raw_infohash, all_torrents[i].1).expect("failed to zadd");
+        new_server.zadd::<&str, f64, &Vec<u8>, ()>("TORRENTS", &raw_infohash, all_torrents[i].1).expect("failed to zadd");
     }
-
-    // unsafe  {
-    //     let tuple = &all_torrents[0];
-    //     println!("First guy: {:?}", std::str::from_utf8_unchecked(&tuple.0));
-    //     let decoded = hex::decode(&tuple.0).expect("failed to decode");
-    //     println!("First raw: {:2X?}", decoded);
-    //     println!("Score is: {:?}", tuple.1);
-    //     r_new.zadd::<&str, f64, &Vec<u8>, ()>("TORRENTS", &decoded, tuple.1).expect("failed to zadd");
-    // }
 }

--- a/examples/redis_fix_keys.rs
+++ b/examples/redis_fix_keys.rs
@@ -1,0 +1,29 @@
+use redis::Commands;
+
+fn main(){
+    let mut r_old = redis::Client::open("redis://127.0.0.1:6379").unwrap();
+    let mut r_new = redis::Client::open("redis://127.0.0.1:6363").unwrap();
+
+    // All torrents are in the ZSET TORRENTS
+    let all_torrents: Vec<(Vec<u8>, f64)> = r_old.zrangebyscore_withscores("TORRENTS", "-inf", "+inf").expect("failed to ZRANGEBYSCORE");
+
+    println!("Got {} torrents", all_torrents.len());
+
+    for i in 0..all_torrents.len() {
+        if i % 10000 == 0 {
+            println!("Currently doing torrent #{}", i + 1);
+        }
+
+        let raw_infohash = hex::decode(&all_torrents[i].0).expect("Failed to decode");
+        r_new.zadd::<&str, f64, &Vec<u8>, ()>("TORRENTS", &raw_infohash, all_torrents[i].1).expect("failed to zadd");
+    }
+
+    // unsafe  {
+    //     let tuple = &all_torrents[0];
+    //     println!("First guy: {:?}", std::str::from_utf8_unchecked(&tuple.0));
+    //     let decoded = hex::decode(&tuple.0).expect("failed to decode");
+    //     println!("First raw: {:2X?}", decoded);
+    //     println!("Score is: {:?}", tuple.1);
+    //     r_new.zadd::<&str, f64, &Vec<u8>, ()>("TORRENTS", &decoded, tuple.1).expect("failed to zadd");
+    // }
+}


### PR DESCRIPTION
A BitTorrent SHA1 hash is only 20 bytes. However, currently kiryuu uses the serialized hex-string of the infohash as the keys in redis (and also the values in the `TORRENTS ZSET`).

This wastes a lot of memory in redis, since we're using 40 bytes in several places where we could be using just 20.

This MR introduces a migratory script which can help verify the space savings (see: #54 ).

Note: Also need to update the `make_redis_keys` fn to make the newer keys so they're actually used (and potentially the kouko cleaner...)