### PR TITLE
Scrape 404

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Test
         run: cargo test --verbose
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: kiryuu
           path: ./target/debug/kiryuu

--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -35,7 +35,7 @@ jobs:
           - /qbit-svc/watch:/watch
 
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: kiryuu
 
@@ -90,7 +90,7 @@ jobs:
         run: kill -9 `lsof -i:6969 -t`
 
       - name: Upload tcpdump logs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: tcpdump_logs
           path: |
@@ -131,7 +131,7 @@ jobs:
           --health-retries 5
 
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: kiryuu
 

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Check linkage
         run: ldd ./target/x86_64-unknown-linux-musl/release/kiryuu
       
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: kiryuu-static-${{ github.sha }}
           path: ./target/x86_64-unknown-linux-musl/release/kiryuu

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,7 @@ mod constants;
 mod req_log;
 mod db;
 
-use actix_web::{dev::Service, get, http::{header, StatusCode}, web::{self, Redirect}, App, HttpRequest, HttpResponse, HttpServer, Responder};
+use actix_web::{dev::Service, error::ErrorNotFound, get, http::{header, StatusCode}, web::{self, Redirect}, App, HttpRequest, HttpResponse, HttpServer, Responder};
 use db::get_hash_keys_scan;
 use std::time::{SystemTime, UNIX_EPOCH};
 use clap::Parser;
@@ -357,6 +357,9 @@ async fn main() -> std::io::Result<()> {
         })
         .service(healthz)
         .service(announce)
+        .service(web::resource("/scrape").to(|| async {
+            HttpResponse::build(StatusCode::NOT_FOUND).finish()
+        }))
         .default_service(web::to(|| async {
             Redirect::to(HOMEPAGE)
         }))


### PR DESCRIPTION
For `/scrape` endpoint return 404 to make it clear it's not supported. 

This is to avoid all the BT clients from actually hitting the mywaifu homepage for a scrape request leading to NGINX load